### PR TITLE
fix!: fixed the typo in var.down_reccurrence

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "up_recurrence" {
   default     = "0 6 * * MON-FRI"
 }
 
-variable "down_reccurence" {
+variable "down_recurrence" {
   description = "Down Reccurence"
   default     = "0 20 * * *"
 }


### PR DESCRIPTION
Fixes the typo in `down_reccurrence` in the variables section.

BREAKING-CHANGE: Change `down_reccurrence` in the module call to `down_recurrence`.