### PR TITLE
fix: validate the aws:ResourceTag of the instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "ssm_access" {
     condition {
       test = "ForAnyValue:StringEqualsIfExists"
       values = [local.access_tag_value]
-      variable = "ssm:resourceTag/${local.access_tag_key}"
+      variable = "aws:ResourceTag/${local.access_tag_key}"
     }
   }
   statement {


### PR DESCRIPTION
Changes the policy to allow the SSH key transfer and start session for all instances having the mentioned `aws:ResourceTag`. It doesn't work with `ssm:resourceTag`.